### PR TITLE
 Fixes issue#8 output file metadata .MOV -> .mp4

### DIFF
--- a/ios/Classes/SwiftVideoCompressPlugin.swift
+++ b/ios/Classes/SwiftVideoCompressPlugin.swift
@@ -166,7 +166,7 @@ public class SwiftVideoCompressPlugin: NSObject, FlutterPlugin {
                                _ duration: Double?,_ includeAudio: Bool?,_ frameRate: Int?,
                                _ result: @escaping FlutterResult) {
         let sourceVideoUrl = Utility.getPathUrl(path)
-        let sourceVideoType = sourceVideoUrl.pathExtension
+        let sourceVideoType = "mp4"
         
         let sourceVideoAsset = avController.getVideoAsset(sourceVideoUrl)
         let sourceVideoTrack = avController.getTrack(sourceVideoAsset)


### PR DESCRIPTION
I believe originally it defaulted to the input extension of the original file

now its modified to match the output file type (.mp4)