### PR TITLE
Fixes issue#5 Android compression progress

### DIFF
--- a/lib/src/video_compressor.dart
+++ b/lib/src/video_compressor.dart
@@ -28,15 +28,9 @@ class VideoCompress {
   Future<void> _handleCallback(MethodCall call) async {
     switch (call.method) {
       case 'updateProgress':
-        final progress = double.tryParse(call.arguments);
-        _updateProgressState(progress);
+        final progress = double.tryParse(call.arguments.toString());
+        if(progress != null) this.compressProgress$.next(progress);
         break;
-    }
-  }
-
-  void _updateProgressState(double state) {
-    if (state != null) {
-      compressProgress$.next(state);
     }
   }
 


### PR DESCRIPTION
Removed unnecessary step for progress indicator

forced input in method handle call into String type so tryParse for double can work

Android was sending double type while iOS was sending a String type. 

Now progress indicator works fine on Android and iOS