### PR TITLE
Change iOS default quality to Medium

### DIFF
--- a/ios/Classes/SwiftVideoCompressPlugin.swift
+++ b/ios/Classes/SwiftVideoCompressPlugin.swift
@@ -140,12 +140,14 @@ public class SwiftVideoCompressPlugin: NSObject, FlutterPlugin {
     
     private func getExportPreset(_ quality: NSNumber)->String {
         switch(quality) {
+        case 1:
+            return AVAssetExportPresetLowQuality
         case 2:
             return AVAssetExportPresetMediumQuality
         case 3:
             return AVAssetExportPresetHighestQuality
         default:
-            return AVAssetExportPresetLowQuality
+            return AVAssetExportPresetMediumQuality
         }
     }
     


### PR DESCRIPTION
This should fix #6 , Medium quality seems like the most sane default to me.

Currently opening this as a draft, because I haven't had a chance to test this yet. 