### PR TITLE
Fix registration in isolate with V2 embedding

### DIFF
--- a/android/src/main/kotlin/com/example/video_compress/VideoCompressPlugin.kt
+++ b/android/src/main/kotlin/com/example/video_compress/VideoCompressPlugin.kt
@@ -1,15 +1,13 @@
 package com.example.video_compress
 
-import android.app.Activity
 import android.content.Context
-import android.content.Intent
 import android.net.Uri
 import com.otaliastudios.transcoder.Transcoder
 import com.otaliastudios.transcoder.TranscoderListener
-import com.otaliastudios.transcoder.strategy.DefaultVideoStrategies
 import com.otaliastudios.transcoder.strategy.DefaultVideoStrategy
 import com.otaliastudios.transcoder.strategy.TrackStrategy
-import com.otaliastudios.transcoder.strategy.size.*
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
@@ -22,10 +20,13 @@ import java.util.*
 /**
  * VideoCompressPlugin
  */
-class VideoCompressPlugin private constructor(private val activity: Activity, private val context: Context, private val channel: MethodChannel) : MethodCallHandler {
+class VideoCompressPlugin : MethodCallHandler, FlutterPlugin {
+    private var context: Context? = null
+    private var channel: MethodChannel? = null
 
     var channelName = "video_compress"
     override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+        if (context == null || channel == null) return
 
         when (call.method) {
             "getByteThumbnail" -> {
@@ -38,15 +39,15 @@ class VideoCompressPlugin private constructor(private val activity: Activity, pr
                 val path = call.argument<String>("path")
                 val quality = call.argument<Int>("quality")!!
                 val position = call.argument<Int>("position")!! // to long
-                ThumbnailUtility("video_compress").getFileThumbnail(context, path!!, quality,
+                ThumbnailUtility("video_compress").getFileThumbnail(context!!, path!!, quality,
                         position.toLong(), result)
             }
             "getMediaInfo" -> {
                 val path = call.argument<String>("path")
-                result.success(Utility(channelName).getMediaInfoJson(context, path!!).toString())
+                result.success(Utility(channelName).getMediaInfoJson(context!!, path!!).toString())
             }
             "deleteAllCache" -> {
-                result.success(Utility(channelName).deleteAllCache(context, result));
+                result.success(Utility(channelName).deleteAllCache(context!!, result));
             }
             "cancelCompression" -> {
                 result.success(false);
@@ -61,7 +62,7 @@ class VideoCompressPlugin private constructor(private val activity: Activity, pr
                 val includeAudio = call.argument<Boolean>("includeAudio")
                 val frameRate = if (call.argument<Int>("frameRate")==null) 30 else call.argument<Int>("frameRate")
 
-                val tempDir: String = this.context.getExternalFilesDir("video_compress")!!.absolutePath
+                val tempDir: String = context!!.getExternalFilesDir("video_compress")!!.absolutePath
                 val out = SimpleDateFormat("yyyy-MM-dd hh-mm-ss").format(Date())
                 val destPath: String = tempDir + File.separator + "VID_" + out + ".mp4"
 
@@ -92,15 +93,15 @@ class VideoCompressPlugin private constructor(private val activity: Activity, pr
 
 
                 Transcoder.into(destPath!!)
-                        .addDataSource(context, Uri.parse(path))
+                        .addDataSource(context!!, Uri.parse(path))
                         .setVideoTrackStrategy(strategy)
                         .setListener(object : TranscoderListener {
                             override fun onTranscodeProgress(progress: Double) {
-                                channel.invokeMethod("updateProgress", progress * 100.00)
+                                channel!!.invokeMethod("updateProgress", progress * 100.00)
                             }
                             override fun onTranscodeCompleted(successCode: Int) {
-                                channel.invokeMethod("updateProgress", 100.00)
-                                val json = Utility(channelName).getMediaInfoJson(context, destPath)
+                                channel!!.invokeMethod("updateProgress", 100.00)
+                                val json = Utility(channelName).getMediaInfoJson(context!!, destPath)
                                 json.put("isCancel", false)
                                 result.success(json.toString())
                                 if (deleteOrigin) {
@@ -123,15 +124,30 @@ class VideoCompressPlugin private constructor(private val activity: Activity, pr
         }
     }
 
+    override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        val plugin = VideoCompressPlugin()
+        plugin.startListening(binding.applicationContext, binding.binaryMessenger)
+    }
+
+    override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        channel = null
+        context = null
+    }
+
+    private fun startListening(context: Context, messenger: BinaryMessenger) {
+        val channel = MethodChannel(messenger, "video_compress")
+        channel.setMethodCallHandler(this)
+        this.context = context
+        this.channel = channel
+    }
+
     companion object {
         const val ACTIVITY_2_REQUEST = 999
 
         @JvmStatic
         fun registerWith(registrar: Registrar) {
-            val channel = MethodChannel(registrar.messenger(), "video_compress")
-            val instance = VideoCompressPlugin(registrar.activity(), registrar.context(), channel)
-            channel.setMethodCallHandler(instance)
+            val plugin = VideoCompressPlugin()
+            plugin.startListening(registrar.context(), registrar.messenger())
         }
     }
-
 }


### PR DESCRIPTION
This PR fixes the `registrar.activity() must not be null` exception caused by the plugin depending on an activity when being registered, which, is not available in an isolate.

While at it, this PR also upgrades to [V2 Embedding](https://flutter.dev/docs/development/packages-and-plugins/plugin-api-migration).

Unfortunately, my time is very limited, so I will only be able to create this PR with a fix on the plugin, and won't be able to spend more time updating the example app as well. For the same reason, I haven't done any testing beyond confirming it works for my use case.