### PR TITLE
[Android, LogLevel] Ability to set log level printings in Android

### DIFF
--- a/android/src/main/kotlin/com/example/video_compress/VideoCompressPlugin.kt
+++ b/android/src/main/kotlin/com/example/video_compress/VideoCompressPlugin.kt
@@ -10,6 +10,7 @@ import com.otaliastudios.transcoder.strategy.DefaultVideoStrategies
 import com.otaliastudios.transcoder.strategy.DefaultVideoStrategy
 import com.otaliastudios.transcoder.strategy.TrackStrategy
 import com.otaliastudios.transcoder.strategy.size.*
+import com.otaliastudios.transcoder.internal.Logger
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
@@ -24,6 +25,8 @@ import java.util.*
  */
 class VideoCompressPlugin private constructor(private val activity: Activity, private val context: Context, private val channel: MethodChannel) : MethodCallHandler {
 
+    private val TAG = "VideoCompressPlugin"
+    private val LOG = Logger(TAG)
     var channelName = "video_compress"
     override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
 
@@ -47,6 +50,11 @@ class VideoCompressPlugin private constructor(private val activity: Activity, pr
             }
             "deleteAllCache" -> {
                 result.success(Utility(channelName).deleteAllCache(context, result));
+            }
+            "setLogLevel" -> {
+                val logLevel = call.argument<Int>("logLevel")!!
+                Logger.setLogLevel(logLevel)
+                result.success(true);
             }
             "cancelCompression" -> {
                 result.success(false);

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -98,6 +98,7 @@ class _MyHomePageState extends State<MyHomePage> {
       floatingActionButton: FloatingActionButton(
         onPressed: () async {
           File file = await ImagePicker.pickVideo(source: ImageSource.gallery);
+          await VideoCompress.setLogLevel(3);
           final info = await VideoCompress.compressVideo(
             file.path,
             quality: VideoQuality.MediumQuality,

--- a/ios/Classes/SwiftVideoCompressPlugin.swift
+++ b/ios/Classes/SwiftVideoCompressPlugin.swift
@@ -49,6 +49,8 @@ public class SwiftVideoCompressPlugin: NSObject, FlutterPlugin {
         case "deleteAllCache":
             Utility.deleteFile(Utility.basePath(), clear: true)
             result(true)
+        case "setLogLevel":
+            result(true)
         default:
             result(FlutterMethodNotImplemented)
         }

--- a/lib/src/video_compressor.dart
+++ b/lib/src/video_compressor.dart
@@ -167,6 +167,12 @@ class VideoCompress {
   static Future<bool> deleteAllCache() async {
     return await _invoke<bool>('deleteAllCache');
   }
+
+  static Future<void> setLogLevel(int logLevel) async {
+    return await _invoke<void>('setLogLevel', {
+      'logLevel': logLevel,
+    });
+  }
 }
 
 class ObservableBuilder<T> {


### PR DESCRIPTION
The amount of prints produced by otaliastudios transcoder is enormous and makes it difficulty to find other prints, which are not produced by that library.
The suggested change allows to control the log level of that library.