### PR TITLE
Give 'includeAudio' parameter the default value of true to make it null safe

### DIFF
--- a/android/src/main/kotlin/com/example/video_compress/VideoCompressPlugin.kt
+++ b/android/src/main/kotlin/com/example/video_compress/VideoCompressPlugin.kt
@@ -80,7 +80,7 @@ class VideoCompressPlugin : MethodCallHandler, FlutterPlugin {
                 val deleteOrigin = call.argument<Boolean>("deleteOrigin")!!
                 val startTime = call.argument<Int>("startTime")
                 val duration = call.argument<Int>("duration")
-                val includeAudio = call.argument<Boolean>("includeAudio")!!
+                val includeAudio = call.argument<Boolean>("includeAudio") ?: true
                 val frameRate = if (call.argument<Int>("frameRate")==null) 30 else call.argument<Int>("frameRate")
 
                 val tempDir: String = context.getExternalFilesDir("video_compress")!!.absolutePath

--- a/lib/src/progress_callback.dart/compress_mixin.dart
+++ b/lib/src/progress_callback.dart/compress_mixin.dart
@@ -8,7 +8,7 @@ class CompressMixin {
 
   @protected
   void initProcessCallback() {
-    _channel.setMethodCallHandler(_progresCallback);
+    _channel.setMethodCallHandler(_progressCallback);
   }
 
   MethodChannel get channel => _channel;
@@ -22,7 +22,7 @@ class CompressMixin {
     _isCompressing = status;
   }
 
-  Future<void> _progresCallback(MethodCall call) async {
+  Future<void> _progressCallback(MethodCall call) async {
     switch (call.method) {
       case 'updateProgress':
         final progress = double.tryParse(call.arguments.toString());


### PR DESCRIPTION
This PR gives the 'includeAudio' parameter the default value of true and fixes the [error](https://github.com/jonataslaw/VideoCompress/issues/57#issuecomment-713076186) of video compression in android as there is no null safe fallback for it and is a required parameter in Android platform code.

This PR also fixes Typo - '_progresCallback' to '_progressCallback'.