### PR TITLE
Invalidate updateProgress timer after the completion of video export

### DIFF
--- a/ios/Classes/SwiftVideoCompressPlugin.swift
+++ b/ios/Classes/SwiftVideoCompressPlugin.swift
@@ -215,8 +215,8 @@ public class SwiftVideoCompressPlugin: NSObject, FlutterPlugin {
                                          userInfo: exporter, repeats: true)
         
         exporter.exportAsynchronously(completionHandler: {
+            timer.invalidate()
             if(self.stopCommand) {
-                timer.invalidate()
                 self.stopCommand = false
                 var json = self.getMediaInfoJson(path)
                 json["isCancel"] = true
@@ -224,7 +224,6 @@ public class SwiftVideoCompressPlugin: NSObject, FlutterPlugin {
                 return result(jsonString)
             }
             if deleteOrigin {
-                timer.invalidate()
                 let fileManager = FileManager.default
                 do {
                     if fileManager.fileExists(atPath: path) {


### PR DESCRIPTION
Hi, Thanks a lot for this handy plugin. 

I found out some update progress issues that came from original plugin, flutter_compress_video.

When you compress multiple videos in a row, the update progress might not be correct. The reason is that the timer from previous compression is still active as long as you hadn't cancel it or you hadn't set deleteOrigin true. Therefore, you could get multiple progress update from current and previous timers during the compression, and this delivers incorrect progress values.

For example, when you are compressing your third video after compressing 2 videos, you could get 3 progress updates from 3 different timers within a given time interval. If you are compressing more videos, the number of active timers will keep increasing.

I fixed this timer issue in this PR.

