### PR TITLE
[Resolution Presets] Support for resolution presets

### DIFF
--- a/android/src/main/kotlin/com/example/video_compress/VideoCompressPlugin.kt
+++ b/android/src/main/kotlin/com/example/video_compress/VideoCompressPlugin.kt
@@ -113,6 +113,18 @@ class VideoCompressPlugin : MethodCallHandler, FlutterPlugin {
                                 .frameRate(frameRate!!) // will be capped to the input frameRate
                                 .build()
                     }
+                    4 -> {
+                        videoTrackStrategy = DefaultVideoStrategy.atMost(480, 640).build()
+                    }
+                    5 -> {
+                        videoTrackStrategy = DefaultVideoStrategy.atMost(540, 960).build()
+                    }
+                    6 -> {
+                        videoTrackStrategy = DefaultVideoStrategy.atMost(720, 1280).build()
+                    }
+                    7 -> {
+                        videoTrackStrategy = DefaultVideoStrategy.atMost(1080, 1920).build()
+                    }                    
                 }
 
                 audioTrackStrategy = if (includeAudio) {

--- a/ios/Classes/SwiftVideoCompressPlugin.swift
+++ b/ios/Classes/SwiftVideoCompressPlugin.swift
@@ -148,6 +148,14 @@ public class SwiftVideoCompressPlugin: NSObject, FlutterPlugin {
             return AVAssetExportPresetMediumQuality
         case 3:
             return AVAssetExportPresetHighestQuality
+        case 4:
+            return AVAssetExportPreset640x480
+        case 5:
+            return AVAssetExportPreset960x540
+        case 6:
+            return AVAssetExportPreset1280x720
+        case 7:
+            return AVAssetExportPreset1920x1080
         default:
             return AVAssetExportPresetMediumQuality
         }

--- a/lib/src/video_compress/video_quality.dart
+++ b/lib/src/video_compress/video_quality.dart
@@ -1,1 +1,10 @@
-enum VideoQuality { DefaultQuality, LowQuality, MediumQuality, HighestQuality }
+enum VideoQuality {
+  DefaultQuality,
+  LowQuality,
+  MediumQuality,
+  HighestQuality,
+  Res640x480Quality,
+  Res960x540Quality,
+  Res1280x720Quality,
+  Res1920x1080Quality
+}

--- a/macos/Classes/VideoCompressPlugin.swift
+++ b/macos/Classes/VideoCompressPlugin.swift
@@ -150,6 +150,14 @@ public class VideoCompressPlugin: NSObject, FlutterPlugin {
             return AVAssetExportPresetMediumQuality
         case 3:
             return AVAssetExportPresetHighestQuality
+        case 4:
+            return AVAssetExportPreset640x480
+        case 5:
+            return AVAssetExportPreset960x540
+        case 6:
+            return AVAssetExportPreset1280x720
+        case 7:
+            return AVAssetExportPreset1920x1080
         default:
             return AVAssetExportPresetMediumQuality
         }


### PR DESCRIPTION
Hi,
This PR contains support for quality based on resolution presets. It widens the `VideoQuality` enumeration, so there are 4 new values (Starting with **`Res`**):
```
enum VideoQuality {
  DefaultQuality,
  LowQuality,
  MediumQuality,
  HighestQuality,
  Res640x480Quality,
  Res960x540Quality,
  Res1280x720Quality,
  Res1920x1080Quality
}
```
Hoping you can quickly submit this and release a new version.

Thanks!
