### PR TITLE
Fix duration on Android to work with seconds

### DIFF
--- a/android/src/main/kotlin/com/example/video_compress/VideoCompressPlugin.kt
+++ b/android/src/main/kotlin/com/example/video_compress/VideoCompressPlugin.kt
@@ -141,7 +141,7 @@ class VideoCompressPlugin : MethodCallHandler, FlutterPlugin {
 
                 val dataSource = if (startTime != null || duration != null){
                     val source = UriDataSource(context, Uri.parse(path))
-                    TrimDataSource(source, (1000 * 1000 * (startTime ?: 0)).toLong(), (1000 * 1000 * (duration ?: 0)).toLong())
+                    TrimDataSource(source, (100 * 100 * (startTime ?: 0)).toLong(), (100 * 100 * (duration ?: 0)).toLong())
                 }else{
                     UriDataSource(context, Uri.parse(path))
                 }


### PR DESCRIPTION
Fixes #127.

Changes multiplier value from thousand to hundred to let the plugin `duration` parameter work with seconds.