### PR TITLE
Update Android compression library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.1.1
 - Fix issue on iOS with files containing whitespaces
+- Update Android compression library
 
 ## 3.1.0
 - Bug fix on getMediaInfo (@trustmefelix)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,5 +41,5 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.otaliastudios:transcoder:0.10.0'
+    implementation 'com.otaliastudios:transcoder:0.10.4'
 }


### PR DESCRIPTION
This PR updates the library used for video compression on Android.

Looks like that library had no breaking changes, but some fixes: https://natario1.github.io/Transcoder/about/changelog

Updated changelog to mention this update.

I believe that this PR should be merged after #153
As soon as #153 is merged I will update this PR to resolve conflicts.