### PR TITLE
Unique file name in case of parallel video compressions

### DIFF
--- a/android/src/main/kotlin/com/example/video_compress/VideoCompressPlugin.kt
+++ b/android/src/main/kotlin/com/example/video_compress/VideoCompressPlugin.kt
@@ -87,7 +87,7 @@ class VideoCompressPlugin : MethodCallHandler, FlutterPlugin {
 
                 val tempDir: String = context.getExternalFilesDir("video_compress")!!.absolutePath
                 val out = SimpleDateFormat("yyyy-MM-dd hh-mm-ss").format(Date())
-                val destPath: String = tempDir + File.separator + "VID_" + out + ".mp4"
+                val destPath: String = tempDir + File.separator + "VID_" + out + path.hashCode() + ".mp4"
 
                 var videoTrackStrategy: TrackStrategy = DefaultVideoStrategy.atMost(340).build();
                 val audioTrackStrategy: TrackStrategy


### PR DESCRIPTION
The gist of this PR:

I have been using `VideoCompress.compressVideo` in parallel by using this call in separate isolates. So since the file name format in Android looks like `VID_dd:mm:yy:ff:mm:ss.mp4`, parallel compressions would make the file name the same for two different files. Which in turn resulted in the corrupted file as output.

Solution: Adding the hashCode() of the incoming path, so that each file has a separate file name.