### PR TITLE
fix: When video name contains space,  filePath forget to decode %20 t…

### DIFF
--- a/lib/src/video_compress/video_compressor.dart
+++ b/lib/src/video_compress/video_compressor.dart
@@ -82,7 +82,7 @@ extension Compress on IVideoCompress {
       'position': position,
     }));
 
-    final file = File(filePath!);
+    final file = File(Uri.decodeFull(filePath!));
 
     return file;
   }


### PR DESCRIPTION
I'm using video_compress 3.1.1.

If origin video contains space, calling `VideoCompress.getFileThumbnail` will result in `filePath` contains %20. Just call `Url.decodeFull` to decode %20, because File() constructor DONOT need encode path.