### PR TITLE
Bump up transcoder to 0.10.5

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,5 +41,5 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.otaliastudios:transcoder:0.9.1'
+    implementation 'com.otaliastudios:transcoder:0.10.5'
 }

--- a/android/src/main/kotlin/com/example/video_compress/VideoCompressPlugin.kt
+++ b/android/src/main/kotlin/com/example/video_compress/VideoCompressPlugin.kt
@@ -13,7 +13,7 @@ import com.otaliastudios.transcoder.strategy.RemoveTrackStrategy
 import com.otaliastudios.transcoder.strategy.TrackStrategy
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.BinaryMessenger
-import com.otaliastudios.transcoder.internal.Logger
+import com.otaliastudios.transcoder.utils.Logger
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler

--- a/android/src/main/kotlin/com/example/video_compress/VideoCompressPlugin.kt
+++ b/android/src/main/kotlin/com/example/video_compress/VideoCompressPlugin.kt
@@ -13,7 +13,7 @@ import com.otaliastudios.transcoder.strategy.RemoveTrackStrategy
 import com.otaliastudios.transcoder.strategy.TrackStrategy
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.BinaryMessenger
-import com.otaliastudios.transcoder.utils.Logger
+import com.otaliastudios.transcoder.internal.utils.Logger
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler


### PR DESCRIPTION
After `jcenter` deprecation, the `transcoder` library is moved to maven from version `0.10.0` and upwards, which caused Android builds to fail using the latest Flutter version.
The changes in this PR aim to fix the above.
Fixes https://github.com/jonataslaw/VideoCompress/issues/260, https://github.com/jonataslaw/VideoCompress/issues/247, https://github.com/jonataslaw/VideoCompress/issues/240, https://github.com/jonataslaw/VideoCompress/issues/209, https://github.com/jonataslaw/VideoCompress/issues/226