### PR TITLE
Removes v1 Flutter Android embedding references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.4
+
+- Removes references to v1 Flutter Android embedding classes.
+
 ## 3.1.3
 
 - Update build.gradle (@dharambudh1)

--- a/android/src/main/kotlin/com/example/video_compress/VideoCompressPlugin.kt
+++ b/android/src/main/kotlin/com/example/video_compress/VideoCompressPlugin.kt
@@ -17,7 +17,6 @@ import com.otaliastudios.transcoder.internal.utils.Logger
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
-import io.flutter.plugin.common.PluginRegistry.Registrar
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.*
@@ -198,12 +197,6 @@ class VideoCompressPlugin : MethodCallHandler, FlutterPlugin {
 
     companion object {
         private const val TAG = "video_compress"
-
-        @JvmStatic
-        fun registerWith(registrar: Registrar) {
-            val instance = VideoCompressPlugin()
-            instance.init(registrar.context(), registrar.messenger())
-        }
     }
 
 }

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
         android:label="example"
-        android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity
             android:name=".MainActivity"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: video_compress
 description: Light library of video manipulation of Flutter. Compress video, remove audio, get video thumbnail from dart code.
-version: 3.1.3
+version: 3.1.4
 homepage: https://github.com/jonataslaw/VideoCompress
 
 environment:


### PR DESCRIPTION
Fixes https://github.com/jonataslaw/VideoCompress/issues/268.

Tested by building a copy of the VideoCompress example app with the changes in https://github.com/flutter/engine/pull/52022 applied. 