### PR TITLE
Release 3.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 - Bump up transcoder to 0.11.2
 - Enhancement: support pass-through audio with more than 2 channels
 - Update build.gradle
-- Update Java version to 11
+- Update example app
 
 ## 3.1.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.1.5
+- Bump up transcoder to 0.11.2
+- Enhancement: support pass-through audio with more than 2 channels
+- Update build.gradle
+- Update Java version to 11
+
 ## 3.1.4
 
 - Removes references to v1 Flutter Android embedding classes.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,21 @@ with `pub`:
 $  pub get
 ```
 
+For Android, in settings.gradle file, update this in pluginManagement [ shown in example app ]
+````
+    buildscript {
+        repositories {
+            mavenCentral()
+            maven {
+                url = uri("https://storage.googleapis.com/r8-releases/raw")
+            }
+        }
+        dependencies {
+            classpath("com.android.tools:r8:8.2.24")
+        }
+    }
+````    
+
 ### 3. Import it
 
 Now in your `Dart` code, you can use: 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,10 +24,6 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
-kotlin {
-    jvmToolchain(11)
-}
-
 android {
     namespace 'com.example.video_compress'
     
@@ -39,11 +35,11 @@ android {
     compileSdk 34
 
     compileOptions {
-        sourceCompatibility 11
-        targetCompatibility 11
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
     }
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = "1.8"
     }
 
     sourceSets {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.1'
+        classpath 'com.android.tools.build:gradle:8.2.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -24,6 +24,10 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
+kotlin {
+    jvmToolchain(11)
+}
+
 android {
     namespace 'com.example.video_compress'
     
@@ -35,11 +39,11 @@ android {
     compileSdk 34
 
     compileOptions {
-        sourceCompatibility 1.8
-        targetCompatibility 1.8
+        sourceCompatibility 11
+        targetCompatibility 11
     }
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
 
     sourceSets {
@@ -56,5 +60,5 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation 'com.otaliastudios:transcoder:0.10.5'
+    implementation 'com.otaliastudios:transcoder:0.11.2'
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,4 @@
+org.gradle.jvmargs=-Xmx2048m
 android.enableJetifier=true
 android.useAndroidX=true
-org.gradle.jvmargs=-Xmx1536M
+android.enableR8.fullMode=false

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-all.zip

--- a/android/src/main/kotlin/com/example/video_compress/VideoCompressPlugin.kt
+++ b/android/src/main/kotlin/com/example/video_compress/VideoCompressPlugin.kt
@@ -130,7 +130,8 @@ class VideoCompressPlugin : MethodCallHandler, FlutterPlugin {
                     val channels = DefaultAudioStrategy.CHANNELS_AS_INPUT
 
                     DefaultAudioStrategy.builder()
-                        .channels(channels)
+//                        .channels(channels)
+                        .channels(2)
                         .sampleRate(sampleRate)
                         .build()
                 } else {

--- a/android/src/main/kotlin/com/example/video_compress/VideoCompressPlugin.kt
+++ b/android/src/main/kotlin/com/example/video_compress/VideoCompressPlugin.kt
@@ -130,8 +130,7 @@ class VideoCompressPlugin : MethodCallHandler, FlutterPlugin {
                     val channels = DefaultAudioStrategy.CHANNELS_AS_INPUT
 
                     DefaultAudioStrategy.builder()
-//                        .channels(channels)
-                        .channels(2)
+                        .channels(channels)
                         .sampleRate(sampleRate)
                         .build()
                 } else {

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -1,4 +1,16 @@
 pluginManagement {
+    buildscript {
+        repositories {
+            mavenCentral()
+            maven {
+                url = uri("https://storage.googleapis.com/r8-releases/raw")
+            }
+        }
+        dependencies {
+            classpath("com.android.tools:r8:8.2.24")
+        }
+    }
+    
     def flutterSdkPath = {
         def properties = new Properties()
         file("local.properties").withInputStream { properties.load(it) }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: video_compress
 description: Light library of video manipulation of Flutter. Compress video, remove audio, get video thumbnail from dart code.
-version: 3.1.4
+version: 3.1.5
 homepage: https://github.com/jonataslaw/VideoCompress
 
 environment:


### PR DESCRIPTION
## 3.1.5
- Bump up transcoder to 0.11.2
- Enhancement: support pass-through audio with more than 2 channels
- Update build.gradle
- Update example app

It fixes the issue "https://github.com/jonataslaw/VideoCompress/issues/279"