### PR TITLE
Thumbnail position fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.5
+- Fix getThumbnail position being supplied in milliseconds, but used as microseconds in Android and seconds in iOS
+
 ## 3.1.4
 
 - Removes references to v1 Flutter Android embedding classes.

--- a/android/src/main/kotlin/com/example/video_compress/VideoCompressPlugin.kt
+++ b/android/src/main/kotlin/com/example/video_compress/VideoCompressPlugin.kt
@@ -49,14 +49,14 @@ class VideoCompressPlugin : MethodCallHandler, FlutterPlugin {
                 val path = call.argument<String>("path")
                 val quality = call.argument<Int>("quality")!!
                 val position = call.argument<Int>("position")!! // to long
-                ThumbnailUtility(channelName).getByteThumbnail(path!!, quality, position.toLong(), result)
+                ThumbnailUtility(channelName).getByteThumbnail(path!!, quality, position.toLong() * 1000, result)
             }
             "getFileThumbnail" -> {
                 val path = call.argument<String>("path")
                 val quality = call.argument<Int>("quality")!!
                 val position = call.argument<Int>("position")!! // to long
                 ThumbnailUtility("video_compress").getFileThumbnail(context, path!!, quality,
-                        position.toLong(), result)
+                        position.toLong() * 1000, result)
             }
             "getMediaInfo" -> {
                 val path = call.argument<String>("path")

--- a/ios/Classes/SwiftVideoCompressPlugin.swift
+++ b/ios/Classes/SwiftVideoCompressPlugin.swift
@@ -65,7 +65,7 @@ public class SwiftVideoCompressPlugin: NSObject, FlutterPlugin {
         assetImgGenerate.appliesPreferredTrackTransform = true
         
         let timeScale = CMTimeScale(track.nominalFrameRate)
-        let time = CMTimeMakeWithSeconds(Float64(truncating: position),preferredTimescale: timeScale)
+        let time = CMTime(seconds: Double(position) / 1000.0, preferredTimescale: timeScale)
         guard let img = try? assetImgGenerate.copyCGImage(at:time, actualTime: nil) else {
             return nil
         }

--- a/lib/src/media/media_data.dart
+++ b/lib/src/media/media_data.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: constant_identifier_names
+
 abstract class Enum<T> {
   final T _value;
 
@@ -106,5 +108,5 @@ class MediaMetadataRetriever<int> extends Enum<int> {
   /// [Android] API level 10
   static const METADATA_KEY_YEAR = MediaMetadataRetriever(8);
 
-  const MediaMetadataRetriever(int value) : super(value);
+  const MediaMetadataRetriever(super.value);
 }

--- a/lib/src/video_compress/video_compressor.dart
+++ b/lib/src/video_compress/video_compressor.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/lib/video_compress.dart
+++ b/lib/video_compress.dart
@@ -1,5 +1,3 @@
-library video_compress;
-
 export 'src/video_compress/video_compressor.dart';
 export 'src/video_compress/video_quality.dart';
 export 'src/media/media_info.dart';

--- a/macos/Classes/VideoCompressPlugin.swift
+++ b/macos/Classes/VideoCompressPlugin.swift
@@ -66,7 +66,7 @@ public class VideoCompressPlugin: NSObject, FlutterPlugin {
         assetImgGenerate.appliesPreferredTrackTransform = true
         
         let timeScale = CMTimeScale(track.nominalFrameRate)
-        let time = CMTimeMakeWithSeconds(Float64(truncating: position),preferredTimescale: timeScale)
+        let time = CMTime(seconds: Double(position) / 1000.0, preferredTimescale: timeScale)
         guard let img = try? assetImgGenerate.copyCGImage(at:time, actualTime: nil) else {
             return nil
         }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: video_compress
 description: Light library of video manipulation of Flutter. Compress video, remove audio, get video thumbnail from dart code.
-version: 3.1.4
+version: 3.1.5
 homepage: https://github.com/jonataslaw/VideoCompress
 
 environment:


### PR DESCRIPTION
The plugin takes the time position to generate the thumbnail in milliseconds, however iOS expects the position in seconds and Android expects it in 