### PR TITLE
Fix: Android plugin error - java.lang.IllegalArgumentException: Unsupported value: 'kotlin.Unit' of type 'class kotlin.Unit'

### DIFF
--- a/android/src/main/kotlin/com/example/video_compress/Utility.kt
+++ b/android/src/main/kotlin/com/example/video_compress/Utility.kt
@@ -129,6 +129,6 @@ class Utility(private val channelName: String) {
 
     fun deleteAllCache(context: Context): Boolean {
         val dir = context.getExternalFilesDir("video_compress")
-        return dir?.deleteRecursively() ?: false
+        return dir?.deleteRecursively() == true
     }
 }

--- a/android/src/main/kotlin/com/example/video_compress/Utility.kt
+++ b/android/src/main/kotlin/com/example/video_compress/Utility.kt
@@ -127,8 +127,8 @@ class Utility(private val channelName: String) {
         return fileName
     }
 
-    fun deleteAllCache(context: Context, result: MethodChannel.Result) {
+    fun deleteAllCache(context: Context): Boolean {
         val dir = context.getExternalFilesDir("video_compress")
-        result.success(dir?.deleteRecursively())
+        return dir?.deleteRecursively() ?: false
     }
 }

--- a/android/src/main/kotlin/com/example/video_compress/VideoCompressPlugin.kt
+++ b/android/src/main/kotlin/com/example/video_compress/VideoCompressPlugin.kt
@@ -63,7 +63,7 @@ class VideoCompressPlugin : MethodCallHandler, FlutterPlugin {
                 result.success(Utility(channelName).getMediaInfoJson(context, path!!).toString())
             }
             "deleteAllCache" -> {
-                result.success(Utility(channelName).deleteAllCache(context, result));
+                result.success(Utility(channelName).deleteAllCache(context));
             }
             "setLogLevel" -> {
                 val logLevel = call.argument<Int>("logLevel")!!


### PR DESCRIPTION
### How to reproduce this error

```dart
    ElevatedButton(
      onPressed: () async {
        await VideoCompress.deleteAllCache();
      },
      child: const Text('Delete all cache'),
    ),
```


### Error:


```log
E/MethodChannel#video_compress(15276): Failed to handle method call
E/MethodChannel#video_compress(15276): java.lang.IllegalArgumentException: Unsupported value: 'kotlin.Unit' of type 'class kotlin.Unit'
E/MethodChannel#video_compress(15276): 	at io.flutter.plugin.common.StandardMessageCodec.writeValue(StandardMessageCodec.java:297)
E/MethodChannel#video_compress(15276): 	at io.flutter.plugin.common.StandardMethodCodec.encodeSuccessEnvelope(StandardMethodCodec.java:61)
E/MethodChannel#video_compress(15276): 	at io.flutter.plugin.common.MethodChannel$IncomingMethodCallHandler$1.success(MethodChannel.java:272)
E/MethodChannel#video_compress(15276): 	at com.example.video_compress.VideoCompressPlugin.onMethodCall(VideoCompressPlugin.kt:67)
E/MethodChannel#video_compress(15276): 	at io.flutter.plugin.common.MethodChannel$IncomingMethodCallHandler.onMessage(MethodChannel.java:267)
E/MethodChannel#video_compress(15276): 	at io.flutter.embedding.engine.dart.DartMessenger.invokeHandler(DartMessenger.java:292)
E/MethodChannel#video_compress(15276): 	at io.flutter.embedding.engine.dart.DartMessenger.lambda$dispatchMessageToQueue$0$io-flutter-embedding-engine-dart-DartMessenger(DartMessenger.java:319)
E/MethodChannel#video_compress(15276): 	at io.flutter.embedding.engine.dart.DartMessenger$$ExternalSyntheticLambda0.run(D8$$SyntheticClass:0)
E/MethodChannel#video_compress(15276): 	at android.os.Handler.handleCallback(Handler.java:883)
E/MethodChannel#video_compress(15276): 	at android.os.Handler.dispatchMessage(Handler.java:100)
E/MethodChannel#video_compress(15276): 	at android.os.Looper.loop(Looper.java:214)
E/MethodChannel#video_compress(15276): 	at android.app.ActivityThread.main(ActivityThread.java:7697)
E/MethodChannel#video_compress(15276): 	at java.lang.reflect.Method.invoke(Native Method)
E/MethodChannel#video_compress(15276): 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:516)
E/MethodChannel#video_compress(15276): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:950)
E/DartMessenger(15276): Uncaught exception in binary message listener
E/DartMessenger(15276): java.lang.IllegalStateException: Reply already submitted
E/DartMessenger(15276): 	at io.flutter.embedding.engine.dart.DartMessenger$Reply.reply(DartMessenger.java:431)
E/DartMessenger(15276): 	at io.flutter.plugin.common.MethodChannel$IncomingMethodCallHandler.onMessage(MethodChannel.java:287)
E/DartMessenger(15276): 	at io.flutter.embedding.engine.dart.DartMessenger.invokeHandler(DartMessenger.java:292)
E/DartMessenger(15276): 	at io.flutter.embedding.engine.dart.DartMessenger.lambda$dispatchMessageToQueue$0$io-flutter-embedding-engine-dart-DartMessenger(DartMessenger.java:319)
E/DartMessenger(15276): 	at io.flutter.embedding.engine.dart.DartMessenger$$ExternalSyntheticLambda0.run(D8$$SyntheticClass:0)
E/DartMessenger(15276): 	at android.os.Handler.handleCallback(Handler.java:883)
E/DartMessenger(15276): 	at android.os.Handler.dispatchMessage(Handler.java:100)
E/DartMessenger(15276): 	at android.os.Looper.loop(Looper.java:214)
E/DartMessenger(15276): 	at android.app.ActivityThread.main(ActivityThread.java:7697)
E/DartMessenger(15276): 	at java.lang.reflect.Method.invoke(Native Method)
E/DartMessenger(15276): 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:516)
E/DartMessenger(15276): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:950)
```