### PR TITLE
fix: fix ios video trimming not working when includeAudio true

### DIFF
--- a/ios/Classes/SwiftVideoCompressPlugin.swift
+++ b/ios/Classes/SwiftVideoCompressPlugin.swift
@@ -214,9 +214,7 @@ public class SwiftVideoCompressPlugin: NSObject, FlutterPlugin {
             exporter.videoComposition = videoComposition
         }
         
-        if !isIncludeAudio {
-            exporter.timeRange = timeRange
-        }
+        exporter.timeRange = timeRange
         
         Utility.deleteFile(compressionUrl.absoluteString)
         


### PR DESCRIPTION
## Issue 
when `includeAudio` is set to true, video will not be trimmed based on `startTime` and `duration` in iOS.