### PR TITLE
chore: support startTime and duration value in milliseconds

### DIFF
--- a/android/src/main/kotlin/com/example/video_compress/VideoCompressPlugin.kt
+++ b/android/src/main/kotlin/com/example/video_compress/VideoCompressPlugin.kt
@@ -139,7 +139,7 @@ class VideoCompressPlugin : MethodCallHandler, FlutterPlugin {
 
                 val dataSource = if (startTime != null || duration != null){
                     val source = UriDataSource(context, Uri.parse(path))
-                    TrimDataSource(source, (1000 * 1000 * (startTime ?: 0)).toLong(), (1000 * 1000 * (duration ?: 0)).toLong())
+                    TrimDataSource(source, (1000  * (startTime ?: 0)).toLong(), (1000  * (duration ?: 0)).toLong())
                 }else{
                     UriDataSource(context, Uri.parse(path))
                 }

--- a/ios/Classes/SwiftVideoCompressPlugin.swift
+++ b/ios/Classes/SwiftVideoCompressPlugin.swift
@@ -188,10 +188,10 @@ public class SwiftVideoCompressPlugin: NSObject, FlutterPlugin {
         Utility.getPathUrl("\(Utility.basePath())/\(Utility.getFileName(path))\(uuid.uuidString).\(sourceVideoType)")
 
         let timescale = sourceVideoAsset.duration.timescale
-        let minStartTime = Double(startTime ?? 0)
+        let minStartTime = Double(startTime ?? 0) / 1000.0
         
         let videoDuration = sourceVideoAsset.duration.seconds
-        let minDuration = Double(duration ?? videoDuration)
+        let minDuration = Double(duration != nil ? ((duration ?? 0) / 1000.0) : videoDuration)
         let maxDurationTime = minStartTime + minDuration < videoDuration ? minDuration : videoDuration
         
         let cmStartTime = CMTimeMakeWithSeconds(minStartTime, preferredTimescale: timescale)


### PR DESCRIPTION
## Issue
The current `startTime` and `duration` values support seconds only; using milliseconds would provide greater precision for trimming.