### PR TITLE
chore: remove isCompressing checking for concurrent compress.

### DIFF
--- a/lib/src/progress_callback/compress_mixin.dart
+++ b/lib/src/progress_callback/compress_mixin.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+
 import 'subscription.dart';
 
 class CompressMixin {
@@ -12,15 +13,6 @@ class CompressMixin {
   }
 
   MethodChannel get channel => _channel;
-
-  bool _isCompressing = false;
-
-  bool get isCompressing => _isCompressing;
-
-  @protected
-  void setProcessingStatus(bool status) {
-    _isCompressing = status;
-  }
 
   Future<void> _progressCallback(MethodCall call) async {
     switch (call.method) {

--- a/lib/src/video_compress/video_compressor.dart
+++ b/lib/src/video_compress/video_compressor.dart
@@ -133,7 +133,6 @@ extension Compress on IVideoCompress {
       compressProgress\$ stream to know the compressing state.''');
     }
 
-    // ignore: invalid_use_of_protected_member
     final jsonStr = await _invoke<String>('compressVideo', {
       'path': path,
       'quality': quality.index,

--- a/lib/src/video_compress/video_compressor.dart
+++ b/lib/src/video_compress/video_compressor.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -129,19 +128,12 @@ extension Compress on IVideoCompress {
     bool? includeAudio,
     int frameRate = 30,
   }) async {
-    if (isCompressing) {
-      throw StateError('''VideoCompress Error: 
-      Method: compressVideo
-      Already have a compression process, you need to wait for the process to finish or stop it''');
-    }
-
     if (compressProgress$.notSubscribed) {
       debugPrint('''VideoCompress: You can try to subscribe to the 
       compressProgress\$ stream to know the compressing state.''');
     }
 
     // ignore: invalid_use_of_protected_member
-    setProcessingStatus(true);
     final jsonStr = await _invoke<String>('compressVideo', {
       'path': path,
       'quality': quality.index,
@@ -151,9 +143,6 @@ extension Compress on IVideoCompress {
       'includeAudio': includeAudio,
       'frameRate': frameRate,
     });
-
-    // ignore: invalid_use_of_protected_member
-    setProcessingStatus(false);
 
     if (jsonStr != null) {
       final jsonMap = json.decode(jsonStr);


### PR DESCRIPTION
## Issue
The current `VideoCompress.compressVideo` method can only be called once at a time due to the `isCompressing` flag blocking concurrent executions. As a result, using `Future.wait([VideoCompress.compressVideo(), VideoCompress.compressVideo(), ...])` fails.

## Changes
Removed `isCompressing` to allow concurrent executions using `Future.wait([...])`.