### PR TITLE
fix: fix portrait iOS video containing black padding after exporting.

### DIFF
--- a/ios/Classes/AvController.swift
+++ b/ios/Classes/AvController.swift
@@ -42,6 +42,16 @@ class AvController: NSObject {
         }
     }
     
+    public func isVideoRotatedToPortraitUp(_ track: AVAssetTrack) -> Bool {
+        let t = track.preferredTransform
+        return t.b == 1 && t.c == -1
+    }
+    
+    public func isVideoRotatedToPortraitUpsideDown(_ track: AVAssetTrack) -> Bool {
+        let t = track.preferredTransform
+        return t.b == -1 && t.c == 1
+    }
+    
     public func getMetaDataByTag(_ asset:AVAsset,key:String)->String {
         for item in asset.commonMetadata {
             if item.commonKey?.rawValue == key {

--- a/ios/Classes/SwiftVideoCompressPlugin.swift
+++ b/ios/Classes/SwiftVideoCompressPlugin.swift
@@ -171,7 +171,25 @@ public class SwiftVideoCompressPlugin: NSObject, FlutterPlugin {
             return sourceVideoTrack.asset!
         }
         
-        return composition    
+        return composition
+    }
+    
+    private func getVideoAdjustedSize(_ sourceVideoTrack: AVAssetTrack) -> CGSize {
+        var transform = sourceVideoTrack.preferredTransform
+        var adjustedSize = sourceVideoTrack.naturalSize.applying(transform)
+        adjustedSize.width = abs(adjustedSize.width)
+        adjustedSize.height = abs(adjustedSize.height)
+        return adjustedSize
+    }
+    
+    private func getVideoTransform(videoTrack sourceVideoTrack: AVAssetTrack, videoSize: CGSize) -> CGAffineTransform {
+        var transform = sourceVideoTrack.preferredTransform
+        if avController.isVideoRotatedToPortraitUp(sourceVideoTrack) {
+            transform.tx = videoSize.width
+        } else if avController.isVideoRotatedToPortraitUpsideDown(sourceVideoTrack) {
+            transform.ty = videoSize.height
+        }
+        return transform
     }
     
     private func compressVideo(_ path: String,_ quality: NSNumber,_ deleteOrigin: Bool,_ startTime: Double?,
@@ -211,6 +229,22 @@ public class SwiftVideoCompressPlugin: NSObject, FlutterPlugin {
         if frameRate != nil {
             let videoComposition = AVMutableVideoComposition(propertiesOf: sourceVideoAsset)
             videoComposition.frameDuration = CMTimeMake(value: 1, timescale: Int32(frameRate!))
+            if let sourceVideoTrack {
+                let adjustedSize = getVideoAdjustedSize(sourceVideoTrack)
+                videoComposition.renderSize = adjustedSize
+                
+                let transform = getVideoTransform(videoTrack: sourceVideoTrack, videoSize: adjustedSize)
+                
+                let instruction = AVMutableVideoCompositionInstruction()
+                instruction.timeRange = CMTimeRange(start: .zero, duration: sourceVideoAsset.duration)
+                
+                let layerInstruction = AVMutableVideoCompositionLayerInstruction(assetTrack: sourceVideoTrack)
+                
+                layerInstruction.setTransform(transform, at: .zero)
+                
+                instruction.layerInstructions = [layerInstruction]
+                videoComposition.instructions = [instruction]
+            }
             exporter.videoComposition = videoComposition
         }
         


### PR DESCRIPTION
## Issue
iOS video in portrait mode contains black padding after exporting. Related to: https://github.com/jonataslaw/VideoCompress/issues/195